### PR TITLE
docs: add style guide

### DIFF
--- a/docs/AUDIT.local.md
+++ b/docs/AUDIT.local.md
@@ -1,0 +1,19 @@
+# Execution-Ready Task List (Local Progress)
+
+## Milestone 1: Establish Standards
+- [x] Add Style Guide
+- [ ] Document Build/Test Workflow
+
+## Milestone 2: Improve Test Coverage
+- [ ] Refactor Tests to Use Assertions
+- [ ] Introduce Mocked Database Fixtures
+
+## Milestone 3: Modularize Application Code
+- [ ] Extract Database Layer
+- [ ] Separate UI Components
+
+## Milestone 4: Dependency Management
+- [ ] Update Requirements and Introduce Locking
+
+## Milestone 5: Database Handling
+- [ ] Provide Database Initialization Script

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -1,11 +1,12 @@
 # Style Guide
 
 ## Python
-- Follow [PEP 8](https://peps.python.org/pep-0008/) and enforce with `flake8`.
+- Follow [PEP 8](https://peps.python.org/pep-0008/) and enforce with `flake8` using the shared configuration file (e.g., `.flake8` or `setup.cfg`).
 - Maximum line length: 79 characters.
 - Sort imports alphabetically using `isort`.
 - Write clear names and docstrings for modules, classes, and functions.
 - Avoid unused variables and committed build artifacts.
+- Use the `.flake8` or `setup.cfg` file in the repository to ensure consistent linting rules.
 
 ## Git
 - Commit message format: `<scope>: <imperative summary>`.

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -1,0 +1,18 @@
+# Style Guide
+
+## Python
+- Follow [PEP 8](https://peps.python.org/pep-0008/) and enforce with `flake8`.
+- Maximum line length: 79 characters.
+- Sort imports alphabetically using `isort`.
+- Write clear names and docstrings for modules, classes, and functions.
+- Avoid unused variables and committed build artifacts.
+
+## Git
+- Commit message format: `<scope>: <imperative summary>`.
+- Reference issues or tasks on a new line: `Refs: <id>`.
+- Keep commits focused and atomic.
+
+## Testing
+- Lint code with `flake8` before committing.
+- Run `pytest` and ensure all tests pass.
+- Add tests for new behavior and update existing ones when needed.

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -10,6 +10,9 @@
 
 ## Git
 - Commit message format: `<scope>: <imperative summary>`.
+  Examples:
+    - `feat: add user authentication`
+    - `fix: resolve database connection timeout`
 - Reference issues or tasks on a new line: `Refs: <id>`.
 - Keep commits focused and atomic.
 


### PR DESCRIPTION
Problem:
Repository lacked a documented coding standard.

Approach:
Added `docs/styleguide.md` defining Python style, git conventions, and testing expectations. Logged progress in `docs/AUDIT.local.md`.

Alternatives considered:
None.

Risk & mitigations:
Guidelines may drift from practice; establishing baseline lint/test runs to track.

Affected files:
- docs/styleguide.md
- docs/AUDIT.local.md

Test results (from COMMANDS.sh):
- `python -m flake8 src tests` (failed: tests/test_vat_features.py:163:1 W293 and 20 others)
- `pytest tests` (passed: 8 passed, 8 warnings)

Refs: AUDIT-1

------
https://chatgpt.com/codex/tasks/task_e_68992e5705c083229d9132fc1dccabbc