### PR TITLE
docs: document build and test workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,4 +250,14 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🔧 Development
 
-See the [Technical Specification](docs/technical-specification.md) for detailed architecture information and the [Porting Guide](docs/porting-guide.md) for implementation in other languages.
+See the [Technical Specification](docs/technical-specification.md) for detailed
+architecture information and the [Porting Guide](docs/porting-guide.md) for
+implementation in other languages.
+
+Refer to [build-test-workflow.md](docs/build-test-workflow.md) for build and
+test instructions. Basic commands:
+
+```
+python -m flake8 src tests
+pytest
+```

--- a/docs/AUDIT.local.md
+++ b/docs/AUDIT.local.md
@@ -2,7 +2,7 @@
 
 ## Milestone 1: Establish Standards
 - [x] Add Style Guide
-- [ ] Document Build/Test Workflow
+- [x] Document Build/Test Workflow
 
 ## Milestone 2: Improve Test Coverage
 - [ ] Refactor Tests to Use Assertions

--- a/docs/build-test-workflow.md
+++ b/docs/build-test-workflow.md
@@ -1,0 +1,24 @@
+# Build and Test Workflow
+
+Follow these steps to prepare the environment, lint the code, and run tests.
+
+## Environment Setup
+- Create a virtual environment.
+- Install dependencies:
+  ```bash
+  pip install -r requirements-dev.txt
+  ```
+
+## Lint
+Run `flake8` to enforce style:
+```bash
+python -m flake8 src tests
+```
+
+## Test
+Execute the test suite:
+```bash
+pytest
+```
+
+See [styleguide.md](styleguide.md) for coding conventions.

--- a/docs/build-test-workflow.md
+++ b/docs/build-test-workflow.md
@@ -21,4 +21,4 @@ Execute the test suite:
 pytest
 ```
 
-See [styleguide.md](styleguide.md) for coding conventions.
+See [styleguide.md](docs/styleguide.md) for coding conventions.


### PR DESCRIPTION
Problem:
README lacked guidance on running linting and tests.

Approach:
Added docs/build-test-workflow.md and linked it from README. Updated AUDIT.local.md to mark the task complete.

Alternatives considered:
Keeping instructions solely in README.

Risk & mitigations:
Documentation may drift from tooling; keep in sync with style guide.

Affected files:
- README.md
- docs/build-test-workflow.md
- docs/AUDIT.local.md

Test results (from COMMANDS.sh):
- `python -m flake8 src tests` (failed: style errors)
- `pytest` (failed: ImportError: libGL.so.1)

Refs: audit-task-1.2

------
https://chatgpt.com/codex/tasks/task_e_6899304f376c832296dfdf7b48dea80d