### PR TITLE
tests: refactor VAT integration test with asserts

### DIFF
--- a/docs/AUDIT.local.md
+++ b/docs/AUDIT.local.md
@@ -6,6 +6,10 @@
 
 ## Milestone 2: Improve Test Coverage
 - [ ] Refactor Tests to Use Assertions
+  - [x] tests/test_vat_integration.py
+  - [ ] tests/test_vat_features.py
+  - [ ] tests/test_management.py
+  - [ ] tests/test_implementation.py
 - [ ] Introduce Mocked Database Fixtures
 
 ## Milestone 3: Modularize Application Code

--- a/tests/test_vat_integration.py
+++ b/tests/test_vat_integration.py
@@ -17,7 +17,8 @@ def test_application_launch_with_vat_summary():
     if app is None:
         app = QApplication(sys.argv)
 
-    page = InvoiceListPage()
+    main_window = MainWindow()
+    page = main_window.invoice_list_page
 
     detail_widget = page.detail_widget
     assert hasattr(detail_widget, "vat_table")

--- a/tests/test_vat_integration.py
+++ b/tests/test_vat_integration.py
@@ -6,7 +6,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from PyQt5.QtWidgets import QApplication  # noqa: E402
-from main_with_management import InvoiceListPage, init_database  # noqa: E402
+from main_with_management import MainWindow, init_database  # noqa: E402
 
 
 def test_application_launch_with_vat_summary():

--- a/tests/test_vat_integration.py
+++ b/tests/test_vat_integration.py
@@ -20,7 +20,13 @@ def test_application_launch_with_vat_summary():
     main_window = MainWindow()
     page = main_window.invoice_list_page
 
-    detail_widget = page.detail_widget
+    # Simulate the original object hierarchy
+    class Window:
+        pass
+    window = Window()
+    window.invoice_page = page
+
+    detail_widget = window.invoice_page.detail_widget
     assert hasattr(detail_widget, "vat_table")
     assert detail_widget.vat_table.columnCount() > 0
     assert hasattr(detail_widget, "update_vat_summary")

--- a/tests/test_vat_integration.py
+++ b/tests/test_vat_integration.py
@@ -1,79 +1,25 @@
 #!/usr/bin/env python3
-"""
-Quick test to verify VAT summary works with the main application
-"""
+"""Quick test to verify VAT summary works with the main application."""
 import sys
 from pathlib import Path
 
-# Add current directory to path
-sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-def test_application_launch():
-    """Test launching the application with VAT summary"""
-    print("🧪 Testing Application Launch with VAT Summary...")
-    
-    try:
-        from PyQt5.QtWidgets import QApplication
-        from main_with_management import MainWindow, init_database
-        
-        # Initialize database
-        init_database()
-        
-        # Create QApplication
+from PyQt5.QtWidgets import QApplication  # noqa: E402
+from main_with_management import InvoiceListPage, init_database  # noqa: E402
+
+
+def test_application_launch_with_vat_summary():
+    """Application launches and exposes VAT summary components."""
+    init_database()
+
+    app = QApplication.instance()
+    if app is None:
         app = QApplication(sys.argv)
-        
-        print("✅ PyQt5 Application created")
-        
-        # Create main window
-        window = MainWindow()
-        print("✅ MainWindow created successfully")
-        
-        # Check if the invoice detail widget has VAT summary components
-        if hasattr(window, 'invoice_page'):
-            detail_widget = window.invoice_page.detail_widget
-            
-            if hasattr(detail_widget, 'vat_table'):
-                print("✅ VAT summary table found in detail widget")
-                print(f"   📊 VAT table columns: {detail_widget.vat_table.columnCount()}")
-            else:
-                print("❌ VAT summary table not found")
-                return False
-                
-            if hasattr(detail_widget, 'update_vat_summary'):
-                print("✅ VAT summary update method found")
-            else:
-                print("❌ VAT summary update method not found")
-                return False
-        else:
-            print("⚠️  Could not access invoice page for testing")
-        
-        print("✅ Application ready with VAT summary feature")
-        return True
-        
-    except Exception as e:
-        print(f"❌ Application launch test failed: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
 
-def main():
-    print("🚀 VAT Summary Application Test")
-    print("=" * 40)
-    
-    if test_application_launch():
-        print("\n🎉 VAT Summary feature successfully integrated!")
-        print("\n📋 Enhanced Invoice Features:")
-        print("   ✅ Detailed VAT breakdown by rate")
-        print("   ✅ Professional VAT summary table")
-        print("   ✅ Enhanced totals display")
-        print("   ✅ Automatic calculations")
-        print("\n🏃 Ready to use: python launch_app.py")
-        print("💡 Select any invoice to see the new VAT summary!")
-    else:
-        print("\n❌ VAT summary integration test failed")
-        return 1
-    
-    return 0
+    page = InvoiceListPage()
 
-if __name__ == "__main__":
-    sys.exit(main())
+    detail_widget = page.detail_widget
+    assert hasattr(detail_widget, "vat_table")
+    assert detail_widget.vat_table.columnCount() > 0
+    assert hasattr(detail_widget, "update_vat_summary")


### PR DESCRIPTION
Problem:
Existing VAT integration test relied on print statements, providing no automated verification.

Approach:
Converted tests/test_vat_integration.py to use pytest assertions and updated docs/AUDIT.local.md to track progress.

Alternatives considered:
Leaving print-based checks.

Risk & mitigations:
PyQt5 requires GUI dependencies; installed libgl1 and used QT_QPA_PLATFORM=offscreen to run tests headlessly.

Affected files:
- docs/AUDIT.local.md
- tests/test_vat_integration.py

Test results (from COMMANDS.sh):
- `python -m flake8 src tests || true` (fails: existing style issues remain)
- `python -m flake8 tests/test_vat_integration.py`
- `QT_QPA_PLATFORM=offscreen pytest tests/test_vat_integration.py -q`

Refs: AUDIT#Refactor-Tests

------
https://chatgpt.com/codex/tasks/task_e_689932279504832280ca02f4c8a09f75