### PR TITLE
tests: refactor implementation tests

### DIFF
--- a/tests/test_vat_integration.py
+++ b/tests/test_vat_integration.py
@@ -18,7 +18,7 @@ def test_application_launch_with_vat_summary():
         app = QApplication(sys.argv)
 
     main_window = MainWindow()
-    page = main_window.invoice_list_page
+    page = main_window.list_page
 
     # Simulate the original object hierarchy
     class Window:


### PR DESCRIPTION
Problem:
Tests relied on print statements and outdated attributes, providing no real assertions. The invoice test also reused the production database, risking state pollution between runs. Documentation about the temporary database fixture was missing.

Approach:
Introduced pytest assertions with a shared offscreen QApplication fixture and updated VAT integration to use the current window API. Added an isolated database fixture patched to a temporary path and documented its per-test usage to avoid concurrent access.

Alternatives considered:
Retaining print-based checks or skipping the database isolation fix.

Risk & mitigations:
Qt GUI usage in headless mode may surface platform issues; enforced offscreen mode and documented fixture constraints mitigate this.

Affected files:
- tests/test_implementation.py
- tests/test_vat_integration.py

Test results (from COMMANDS.sh):
- `python -m flake8 src tests` (fails: style issues in src/professional_invoice_manager/config.py and tests/test_management.py)
- `python -m flake8 tests/test_implementation.py tests/test_vat_integration.py`
- `pytest tests`

Refs: #2

------
https://chatgpt.com/codex/tasks/task_e_68999e9bde408322836183ecaa499520