### PR TITLE
test: isolate tests with temporary SQLite DB

### DIFF
--- a/docs/build-test-workflow.md
+++ b/docs/build-test-workflow.md
@@ -21,4 +21,6 @@ Execute the test suite:
 ```bash
 pytest
 ```
+Tests run against a temporary SQLite database provided by fixtures, so the
+repository's `invoice_qt5.db` remains untouched.
 

--- a/src/professional_invoice_manager/config.py
+++ b/src/professional_invoice_manager/config.py
@@ -1,22 +1,19 @@
-"""
-Configuration management for the Invoice Application
-"""
+"""Configuration management for the Invoice Application."""
 
 import json
-import os
-from typing import Dict, Any
 from pathlib import Path
+from typing import Any, Dict
 
 
 class Config:
     """Configuration manager for the application"""
-    
+
     DEFAULT_CONFIG = {
         "database": {
             "path": "invoice_qt5.db",
             "backup_enabled": True,
             "backup_interval_hours": 24,
-            "max_backups": 10
+            "max_backups": 10,
         },
         "ui": {
             "theme": "default",
@@ -24,7 +21,7 @@ class Config:
             "window_height": 640,
             "remember_window_size": True,
             "show_tooltips": True,
-            "confirm_deletions": True
+            "confirm_deletions": True,
         },
         "business": {
             "company_name": "",
@@ -32,25 +29,29 @@ class Config:
             "company_tax_id": "",
             "default_vat_rate": 27,
             "currency": "HUF",
-            "invoice_number_prefix": "INV"
+            "invoice_number_prefix": "INV",
         },
         "export": {
             "default_format": "pdf",
             "auto_open_after_export": True,
-            "export_directory": "exports"
-        }
+            "export_directory": "exports",
+        },
     }
-    
+
     def __init__(self, config_file: str = "config.json"):
         self.config_file = Path(config_file)
         self.config_data = self.DEFAULT_CONFIG.copy()
         self.load_config()
-    
+
     def load_config(self) -> None:
         """Load configuration from file"""
         if self.config_file.exists():
             try:
-                with open(self.config_file, 'r', encoding='utf-8') as f:
+                with open(
+                    self.config_file,
+                    "r",
+                    encoding="utf-8",
+                ) as f:
                     loaded_config = json.load(f)
                     self._merge_config(self.config_data, loaded_config)
             except (json.JSONDecodeError, IOError) as e:
@@ -58,49 +59,57 @@ class Config:
                 self.save_config()  # Save default config
         else:
             self.save_config()  # Create default config file
-    
+
     def save_config(self) -> None:
         """Save current configuration to file"""
         try:
             self.config_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.config_file, 'w', encoding='utf-8') as f:
+            with open(
+                self.config_file,
+                "w",
+                encoding="utf-8",
+            ) as f:
                 json.dump(self.config_data, f, indent=4, ensure_ascii=False)
         except IOError as e:
             print(f"Error: Could not save config file: {e}")
-    
+
     def get(self, key_path: str, default=None) -> Any:
-        """Get configuration value using dot notation (e.g., 'database.path')"""
+        """Get config value using dot notation (e.g., 'database.path')."""
         keys = key_path.split('.')
         value = self.config_data
-        
+
         for key in keys:
             if isinstance(value, dict) and key in value:
                 value = value[key]
             else:
                 return default
-        
+
         return value
-    
+
     def set(self, key_path: str, value: Any) -> None:
         """Set configuration value using dot notation"""
         keys = key_path.split('.')
         config = self.config_data
-        
+
         for key in keys[:-1]:
             if key not in config:
                 config[key] = {}
             config = config[key]
-        
+
         config[keys[-1]] = value
-    
+
     def save(self) -> None:
         """Save configuration to file"""
         try:
-            with open(self.config_file, 'w', encoding='utf-8') as f:
+            with open(
+                self.config_file,
+                "w",
+                encoding="utf-8",
+            ) as f:
                 json.dump(self.config_data, f, indent=2, ensure_ascii=False)
         except Exception as e:
             print(f"Failed to save configuration: {e}")
-    
+
     def _merge_config(self, default: Dict, loaded: Dict) -> None:
         """Recursively merge loaded config with defaults"""
         for key, value in loaded.items():
@@ -109,24 +118,27 @@ class Config:
                     self._merge_config(default[key], value)
                 else:
                     default[key] = value
-    
+
     @property
     def db_path(self) -> str:
         """Get database path"""
         return self.get("database.path", "invoice_qt5.db")
-    
+
     @property
     def window_size(self) -> tuple:
         """Get window size"""
-        return (self.get("ui.window_width", 960), self.get("ui.window_height", 640))
-    
+        return (
+            self.get("ui.window_width", 960),
+            self.get("ui.window_height", 640),
+        )
+
     @property
     def company_info(self) -> Dict[str, str]:
         """Get company information"""
         return {
             "name": self.get("business.company_name", ""),
             "address": self.get("business.company_address", ""),
-            "tax_id": self.get("business.company_tax_id", "")
+            "tax_id": self.get("business.company_tax_id", ""),
         }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+import main_with_management  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def temporary_database(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+
+    def _get_db():
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    monkeypatch.setattr(main_with_management, "get_db", _get_db)
+    main_with_management.init_database()
+    yield


### PR DESCRIPTION
Problem:
Tests wrote to the project's SQLite database, causing unwanted state.

Approach:
- Added an autouse pytest fixture that redirects database connections to a temporary SQLite file and initializes schema.
- Documented that tests run against a temporary database.
- Cleaned configuration module formatting to satisfy flake8.

Alternatives considered:
- Manually managing setup/teardown inside each test case.

Risk & mitigations:
- Temporary database may diverge from production behavior; fixture seeds default schema via `init_database`.

Affected files:
- docs/build-test-workflow.md
- src/professional_invoice_manager/config.py
- tests/conftest.py

Test results (from COMMANDS.sh):
- `python -m flake8 src tests`
- `pytest tests`

Refs: AUDIT#IntroduceMockedDatabaseFixtures

------
https://chatgpt.com/codex/tasks/task_e_6899ec96654883229749259ccefee838