### PR TITLE
refactor: extract partner dialog

### DIFF
--- a/main_with_management.py
+++ b/main_with_management.py
@@ -43,6 +43,7 @@ except ImportError:
     config = SimpleConfig()
 
 from professional_invoice_manager.db import get_db, init_database
+from professional_invoice_manager.dialogs import PartnerFormDialog
 
 
 def format_date(timestamp_or_str):
@@ -294,90 +295,6 @@ class ProductFormDialog(QDialog):
         super().accept()
 
 
-class PartnerFormDialog(QDialog):
-    """Partner (customer/supplier) management dialog"""
-    
-    def __init__(self, partner_data=None, partner_type="customer", parent=None):
-        super().__init__(parent)
-        self.partner_data = partner_data
-        self.partner_type = partner_type
-        
-        type_text = "Vevő" if partner_type == "customer" else "Beszállító"
-        self.setWindowTitle(f"👤 {type_text}" + (" szerkesztése" if partner_data else " hozzáadása"))
-        self.setModal(True)
-        self.resize(500, 400)
-        self.setup_ui()
-        
-        if partner_data:
-            self.load_data()
-    
-    def setup_ui(self):
-        layout = QVBoxLayout(self)
-        
-        # Form layout
-        form_layout = QVBoxLayout()
-        
-        # Name
-        name_layout = QHBoxLayout()
-        name_layout.addWidget(QLabel("🏢 Név:"))
-        self.name_edit = QLineEdit()
-        self.name_edit.setPlaceholderText("Partner neve")
-        name_layout.addWidget(self.name_edit)
-        form_layout.addLayout(name_layout)
-        
-        # Tax ID
-        tax_layout = QHBoxLayout()
-        tax_layout.addWidget(QLabel("🆔 Adószám:"))
-        self.tax_edit = QLineEdit()
-        self.tax_edit.setPlaceholderText("12345678-1-42")
-        tax_layout.addWidget(self.tax_edit)
-        form_layout.addLayout(tax_layout)
-        
-        # Address
-        addr_layout = QVBoxLayout()
-        addr_layout.addWidget(QLabel("🏠 Cím:"))
-        self.address_edit = QLineEdit()
-        self.address_edit.setPlaceholderText("1111 Budapest, Példa utca 1.")
-        addr_layout.addWidget(self.address_edit)
-        form_layout.addLayout(addr_layout)
-        
-        layout.addLayout(form_layout)
-        
-        # Buttons
-        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        buttons.accepted.connect(self.accept)
-        buttons.rejected.connect(self.reject)
-        layout.addWidget(buttons)
-        
-        # Set focus
-        self.name_edit.setFocus()
-    
-    def load_data(self):
-        """Load existing partner data"""
-        if self.partner_data:
-            self.name_edit.setText(self.partner_data.get('name', ''))
-            self.tax_edit.setText(self.partner_data.get('tax_id', '') or '')
-            self.address_edit.setText(self.partner_data.get('address', '') or '')
-    
-    def get_data(self):
-        """Get form data"""
-        return {
-            'name': self.name_edit.text().strip(),
-            'kind': self.partner_type,
-            'tax_id': self.tax_edit.text().strip() or None,
-            'address': self.address_edit.text().strip() or None
-        }
-    
-    def accept(self):
-        """Validate and accept"""
-        data = self.get_data()
-        
-        if not data['name']:
-            QMessageBox.warning(self, "Hiba", "A név mező kitöltése kötelező!")
-            self.name_edit.setFocus()
-            return
-        
-        super().accept()
 
 
 class ManagementListPage(QWidget):

--- a/src/professional_invoice_manager/dialogs.py
+++ b/src/professional_invoice_manager/dialogs.py
@@ -23,9 +23,7 @@ class PartnerFormDialog(QDialog):
 
         type_text = "Vevő" if partner_type == "customer" else "Beszállító"
         self.setWindowTitle(
-            "👤 "
-            + type_text
-            + (" szerkesztése" if partner_data else " hozzáadása")
+            f"👤 {type_text}{' szerkesztése' if partner_data else ' hozzáadása'}"
         )
         self.setModal(True)
         self.resize(500, 400)

--- a/src/professional_invoice_manager/dialogs.py
+++ b/src/professional_invoice_manager/dialogs.py
@@ -1,0 +1,107 @@
+"""Dialog classes for user interactions."""
+
+from PyQt5.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QDialogButtonBox,
+    QMessageBox,
+)
+
+
+class PartnerFormDialog(QDialog):
+    """Partner (customer/supplier) management dialog."""
+
+    def __init__(
+        self, partner_data=None, partner_type="customer", parent=None
+    ):
+        super().__init__(parent)
+        self.partner_data = partner_data
+        self.partner_type = partner_type
+
+        type_text = "Vevő" if partner_type == "customer" else "Beszállító"
+        self.setWindowTitle(
+            "👤 "
+            + type_text
+            + (" szerkesztése" if partner_data else " hozzáadása")
+        )
+        self.setModal(True)
+        self.resize(500, 400)
+        self.setup_ui()
+
+        if partner_data:
+            self.load_data()
+
+    def setup_ui(self):
+        layout = QVBoxLayout(self)
+
+        # Form layout
+        form_layout = QVBoxLayout()
+
+        # Name
+        name_layout = QHBoxLayout()
+        name_layout.addWidget(QLabel("🏢 Név:"))
+        self.name_edit = QLineEdit()
+        self.name_edit.setPlaceholderText("Partner neve")
+        name_layout.addWidget(self.name_edit)
+        form_layout.addLayout(name_layout)
+
+        # Tax ID
+        tax_layout = QHBoxLayout()
+        tax_layout.addWidget(QLabel("🆔 Adószám:"))
+        self.tax_edit = QLineEdit()
+        self.tax_edit.setPlaceholderText("12345678-1-42")
+        tax_layout.addWidget(self.tax_edit)
+        form_layout.addLayout(tax_layout)
+
+        # Address
+        addr_layout = QVBoxLayout()
+        addr_layout.addWidget(QLabel("🏠 Cím:"))
+        self.address_edit = QLineEdit()
+        self.address_edit.setPlaceholderText("1111 Budapest, Példa utca 1.")
+        addr_layout.addWidget(self.address_edit)
+        form_layout.addLayout(addr_layout)
+
+        layout.addLayout(form_layout)
+
+        # Buttons
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        # Set focus
+        self.name_edit.setFocus()
+
+    def load_data(self):
+        """Load existing partner data."""
+        if self.partner_data:
+            self.name_edit.setText(self.partner_data.get('name', ''))
+            self.tax_edit.setText(self.partner_data.get('tax_id', '') or '')
+            self.address_edit.setText(
+                self.partner_data.get('address', '') or ''
+            )
+
+    def get_data(self):
+        """Get form data."""
+        return {
+            'name': self.name_edit.text().strip(),
+            'kind': self.partner_type,
+            'tax_id': self.tax_edit.text().strip() or None,
+            'address': self.address_edit.text().strip() or None,
+        }
+
+    def accept(self):
+        """Validate and accept."""
+        data = self.get_data()
+
+        if not data['name']:
+            QMessageBox.warning(self, "Hiba", "A név mező kitöltése kötelező!")
+            self.name_edit.setFocus()
+            return
+
+        super().accept()

--- a/src/professional_invoice_manager/pages.py
+++ b/src/professional_invoice_manager/pages.py
@@ -1,0 +1,1 @@
+"""Page widgets for management features."""


### PR DESCRIPTION
Problem:
main_with_management.py bundled partner dialog logic, hindering modularity.

Approach:
- Added professional_invoice_manager.dialogs module with PartnerFormDialog.
- Updated main_with_management.py to import PartnerFormDialog from the new module.
- Created placeholder professional_invoice_manager.pages module for future list pages.

Alternatives considered:
- Moving all dialogs and pages in one commit, rejected due to change-size limits.

Risk & mitigations:
- Remaining dialogs and pages still reside in main_with_management.py; to be moved later.
- Tests continue importing from main_with_management for backward compatibility.

Affected files:
- main_with_management.py
- src/professional_invoice_manager/dialogs.py
- src/professional_invoice_manager/pages.py

Test results (from COMMANDS.sh):
- `python -m flake8 src tests`
- `pytest tests`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689a5ebba91c83228eaa7870bc64a621