### PR TITLE
tests: use in-memory SQLite fixture

### DIFF
--- a/src/professional_invoice_manager/dialogs.py
+++ b/src/professional_invoice_manager/dialogs.py
@@ -22,9 +22,8 @@ class PartnerFormDialog(QDialog):
         self.partner_type = partner_type
 
         type_text = "Vevő" if partner_type == "customer" else "Beszállító"
-        self.setWindowTitle(
-            f"👤 {type_text}{' szerkesztése' if partner_data else ' hozzáadása'}"
-        )
+        title_suffix = " szerkesztése" if partner_data else " hozzáadása"
+        self.setWindowTitle(f"👤 {type_text}{title_suffix}")
         self.setModal(True)
         self.resize(500, 400)
         self.setup_ui()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -5,19 +6,21 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
 
-from professional_invoice_manager.config import (  # noqa: E402
-    config as app_config,
-)
 from professional_invoice_manager.db import init_database  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
-def temporary_database(tmp_path):
-    original_db_path = app_config.db_path
-    test_db_path = tmp_path / "test.db"
-    app_config.set("database.path", str(test_db_path))
+def in_memory_db(monkeypatch):
+    original_connect = sqlite3.connect
+    root_conn = original_connect("file::memory:?cache=shared", uri=True)
+    root_conn.row_factory = sqlite3.Row
+
+    def connect(*args, **kwargs):
+        conn = original_connect("file::memory:?cache=shared", uri=True)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
     init_database()
     yield
-    if test_db_path.exists():
-        test_db_path.unlink()
-    app_config.set("database.path", original_db_path)
+    root_conn.close()


### PR DESCRIPTION
Problem:
Existing tests wrote to a temporary on-disk database, slowing runs and risking state leakage. Lint also failed due to a long dialog title line.

Approach:
- Monkeypatch `sqlite3.connect` in an autouse fixture to provide a shared in-memory SQLite database.
- Initialize schema for each test session.
- Shorten dialog title string to satisfy flake8 line-length rules.

Alternatives considered:
- Creating and cleaning temporary files per test.
- Refactoring database layer to accept connections directly.

Risk & mitigations:
- In-memory DB may behave differently than file-based; root connection kept open to maintain schema.

Affected files:
- tests/conftest.py
- src/professional_invoice_manager/dialogs.py

Test results (from COMMANDS.sh):
- `python -m flake8 src tests` ✅
- `pytest tests` ⚠️ ImportError: libGL.so.1 missing

Refs: Milestone 2

------
https://chatgpt.com/codex/tasks/task_e_689a66ae9efc8322925f47b5c2a8002d