### PR TITLE
docs: document build and test workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,16 +248,26 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 └── README.md                  # This file
 ```
 
+## 🧪 Build and Test Workflow
+
+1. Create and activate a virtual environment.
+2. Install development dependencies:
+   ```bash
+   pip install -r requirements-dev.txt
+   ```
+3. Lint the code:
+   ```bash
+   python -m flake8 src tests
+   ```
+4. Run the test suite:
+   ```bash
+   pytest
+   ```
+For more details, see
+[docs/build-test-workflow.md](docs/build-test-workflow.md).
+
 ## 🔧 Development
 
 See the [Technical Specification](docs/technical-specification.md) for detailed
 architecture information and the [Porting Guide](docs/porting-guide.md) for
 implementation in other languages.
-
-Refer to [build-test-workflow.md](docs/build-test-workflow.md) for build and
-test instructions. Basic commands:
-
-```
-python -m flake8 src tests
-pytest
-```


### PR DESCRIPTION
Problem:
README lacked clear build and test instructions.

Approach:
Added a "Build and Test Workflow" section summarizing environment setup, linting, and testing, referencing the dedicated guide.

Alternatives considered:
Relying solely on existing documentation.

Risk & mitigations:
Tests fail in this environment due to missing libGL; no code changes were made.

Affected files:
- README.md

Test results (from COMMANDS.sh):
- `python -m flake8 src tests`
- `pytest` *(fails: ImportError: libGL.so.1)*

Refs: AUDIT#build-test-workflow

------
https://chatgpt.com/codex/tasks/task_e_689a69ca6c1c8322a56e578607f77b09